### PR TITLE
Replace external EventEmitter dependency

### DIFF
--- a/js/utils/event-emitter.js
+++ b/js/utils/event-emitter.js
@@ -1,0 +1,24 @@
+export class EventEmitter {
+    constructor() {
+        this.events = {};
+    }
+
+    on(event, listener) {
+        if (!this.events[event]) {
+            this.events[event] = [];
+        }
+        this.events[event].push(listener);
+    }
+
+    off(event, listener) {
+        if (!this.events[event]) return;
+        this.events[event] = this.events[event].filter(l => l !== listener);
+    }
+
+    emit(event, ...args) {
+        if (!this.events[event]) return;
+        for (const listener of this.events[event]) {
+            listener(...args);
+        }
+    }
+}

--- a/js/ws/client.js
+++ b/js/ws/client.js
@@ -4,7 +4,7 @@
  * 
  * @extends EventEmitter
  */
-import { EventEmitter } from 'https://cdn.skypack.dev/eventemitter3';
+import { EventEmitter } from '../utils/event-emitter.js';
 import { blobToJSON, base64ToArrayBuffer } from '../utils/utils.js';
 
 export class GeminiWebsocketClient extends EventEmitter {


### PR DESCRIPTION
## Summary
- replace CDN EventEmitter import with local version to allow offline use
- implement a small EventEmitter utility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68724b8536e0832ca40dec282da0cbcf